### PR TITLE
real Basic auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ NOTE: If you alter the name of the LaunchDaemon or the Label, you will also need
 #### Optional Reboot
 If after installing all of your packages, you want to force a reboot, simply uncomment the flag in the launchdaemon plist.
 ```xml
-		<string>--reboot</string>
+<string>--reboot</string>
 ```
 
 #### Basic Auth
@@ -92,8 +92,8 @@ Basic dGVzdDp0ZXN0
 In the LaunchDaemon add the following:
 
 ```xml
-		<string>--headers</string>
-    <string>Basic dGVzdDp0ZXN0</string>
+<string>--headers</string>
+<string>Basic dGVzdDp0ZXN0</string>
 ```
 
 ### Building a package

--- a/README.md
+++ b/README.md
@@ -70,6 +70,32 @@ If after installing all of your packages, you want to force a reboot, simply unc
 		<string>--reboot</string>
 ```
 
+#### Basic Auth
+Currently, Basic Authentication is only supported by using `--headers` flag.
+
+The authentication should be passed as a base64 encoded username:password, including the Basic string.
+
+Example:
+
+```python
+import base64
+
+base64.b64encode('test:test')
+'dGVzdDp0ZXN0'
+
+up = base64.b64encode('test:test')
+
+print 'Basic ' + up
+Basic dGVzdDp0ZXN0
+```
+
+In the LaunchDaemon add the following:
+
+```xml
+		<string>--headers</string>
+    <string>Basic dGVzdDp0ZXN0</string>
+```
+
 ### Building a package
 This repository has been setup for use with [munkipkg](https://github.com/munki/munki-pkg). Use `munkipkg` to build your signed installer with the following command:
 
@@ -132,39 +158,4 @@ In order to do this, simply organize your packages in lowercase directories in a
 Then run the tool:
 ```
 python generatejson.py --rootdir /path/to/rootdir
-```
-
-
-
-## Basic Authentication
-If you would like to use basic authentication for your JSON file, in  `installapplications.py` change the following:
-
-```python
-# json data for gurl download
-json_data = {
-        'url': jsonurl,
-        'file': jsonpath,
-    }
-```
-
-### Username/Password
-```python
-# json data for gurl download
-json_data = {
-        'url': jsonurl,
-        'file': jsonpath,
-        'username': 'test',
-        'password': 'test',
-    }
-```
-
-### Headers
-
-```python
-# json data for gurl download
-json_data = {
-        'url': jsonurl,
-        'file': jsonpath,
-        'additional_headers': {'Authorization': 'Basic dGVzdDp0ZXN0'},
-    }
 ```

--- a/payload/usr/local/installapplications/installapplications.py
+++ b/payload/usr/local/installapplications/installapplications.py
@@ -114,6 +114,7 @@ def main():
     # Options
     usage = '%prog [options]'
     o = optparse.OptionParser(usage=usage)
+    o.add_option('--headers', help=('Optional: Auth headers'))
     o.add_option('--jsonurl', help=('Required: URL to json file.'))
     o.add_option('--reboot', default=None,
                  help=('Optional: Trigger a reboot.'), action='store_true')
@@ -143,6 +144,11 @@ def main():
             'file': jsonpath,
         }
 
+    # Grab auth headers if they exist and update the json_data dict.
+    if opts.headers:
+        headers = {'Authorization': opts.headers}
+        json_data.update({'additional_headers': headers})
+
     # Make the temporary folder
     try:
         os.makedirs(iapath)
@@ -166,6 +172,10 @@ def main():
             path = x['file']
             # Check if the file already exists and matches the expected hash.
             while not (os.path.isfile(path) and x['hash'] == gethash(path)):
+                # Check if additional headers are being passed and add them
+                # to the dictionary.
+                if opts.headers:
+                    x.update({'additional_headers': headers})
                 # Download the file once:
                 downloadfile(x)
                 # Wait half a second to process


### PR DESCRIPTION
Basic auth support was broken due to the way we injected the headers.

Now you can pass a `--headers` option and the files will correctly download.