### PR TITLE
fix: Properly trigger on all DEPNotify commands

### DIFF
--- a/payload/private/tmp/installapplications/installapplications.py
+++ b/payload/private/tmp/installapplications/installapplications.py
@@ -192,15 +192,16 @@ def main():
 
     opts, args = o.parse_args()
 
+    # DEPNotify trigger commands that need to happen at the end of a run
+    deptriggers = ['Command: Quit', 'Command: Restart', 'Command: Logout',
+                   'DEPNotifyPath']
+
     # Look for all the DEPNotify options but skip the ones that are usual
     # done after a full run.
     if opts.depnotify:
         for varg in opts.depnotify:
             notification = str(varg)
-            if ('Command: Quit' in notification or
-                'Command: Restart' in notification or
-                'DEPNotifyPath:' in notification or
-                    'Command: LogoutNow' in notification):
+            if any(x in notification for x in deptriggers):
                 continue
             else:
                 deplog(notification)
@@ -358,10 +359,7 @@ def main():
     if opts.depnotify:
         for varg in opts.depnotify:
             notification = str(varg)
-            if ('Command: Quit' in notification or
-                'Command: Restart' in notification or
-                'DEPNotifyPath:' in notification or
-                    'Command: LogoutNow' in notification):
+            if any(x in notification for x in deptriggers):
                 deplog(notification)
             else:
                 iaslog(


### PR DESCRIPTION
This fixes an issue with InstallApplications not properly reading all of the DEPNotifiy end of condition commands. It's also easier to maintain since the list is now a variable.

All flavors (Restart, RestartNow, Logout, etc) have been tested.