### PR TITLE
Download scripts if an url is provided

### DIFF
--- a/build-info.json
+++ b/build-info.json
@@ -10,5 +10,5 @@
         "timestamp": true
     },
     "suppress_bundle_relocation": true,
-    "version": "1.0"
+    "version": "1.1"
 }

--- a/generatejson.py
+++ b/generatejson.py
@@ -54,15 +54,24 @@ def main():
         for d in dirs:
             stages[str(d)] = []
         for file in files:
-            if file.endswith('.pkg'):
-                filepath = os.path.join(subdir, file)
-                filename = os.path.basename(filepath)
-                filehash = gethash(filepath)
-                filestage = os.path.basename(os.path.abspath(
-                            os.path.join(filepath, os.pardir)))
-                filejson = {'file':
-                            '/private/tmp/installapplications/%s' % filename,
-                            'url': '', 'hash': str(filehash), 'name': filename}
+            fileext = os.path.splitext(file)[1]
+            if fileext not in ('.pkg', '.py', '.sh', '.rb', '.php'):
+                continue
+            filepath = os.path.join(subdir, file)
+            filename = os.path.basename(filepath)
+            filehash = gethash(filepath)
+            filestage = os.path.basename(os.path.abspath(
+                        os.path.join(filepath, os.pardir)))
+            filejson = {'file':
+                        '/private/tmp/installapplications/%s' % filename,
+                        'url': '', 'hash': str(filehash), 'name': filename}
+            if fileext == '.pkg':
+                filejson['type'] = 'package'
+                filejson['packageid'] = ''
+                filejson['version'] = ''
+                stages[filestage].append(filejson)
+            else:
+                filejson['type'] = 'rootscript'
                 stages[filestage].append(filejson)
 
     # Saving the file back in the root dir

--- a/generatejson.py
+++ b/generatejson.py
@@ -40,6 +40,8 @@ def main():
         'Required: Root directory path for InstallApplications stages'))
     op.add_option('--outputdir', default=None, help=('Optional: Output \
                   directory to save in. Default saves in the rootdir'))
+    op.add_option('--base-url', default=None, action='store',
+                  help=('Base URL to where root dir is hosted'))
     opts, args = op.parse_args()
 
     if opts.rootdir:
@@ -62,9 +64,14 @@ def main():
             filehash = gethash(filepath)
             filestage = os.path.basename(os.path.abspath(
                         os.path.join(filepath, os.pardir)))
+            if opts.base_url:
+                fileurl = '%s/%s/%s' % (opts.base_url, filestage, filename)
+            else:
+                fileurl = ''
             filejson = {'file':
                         '/private/tmp/installapplications/%s' % filename,
-                        'url': '', 'hash': str(filehash), 'name': filename}
+                        'url': fileurl, 'hash': str(filehash),
+                        'name': filename}
             if fileext == '.pkg':
                 filejson['type'] = 'package'
                 filejson['packageid'] = ''

--- a/payload/Library/Application Support/installapplications/installapplications.py
+++ b/payload/Library/Application Support/installapplications/installapplications.py
@@ -53,12 +53,10 @@ def deplog(text):
 
 
 def iaslog(text):
-    print(text)
     NSLog('[InstallApplications] ' + text)
     if g_dry_run:
-        iaslog = '/tmp/installapplications.log'
-    else:
-        iaslog = '/private/var/log/installapplications.log'
+        return
+    iaslog = '/private/var/log/installapplications.log'
     formatstr = '%b %d %Y %H:%M:%S %z: '
     with open(iaslog, 'a+') as log:
         log.write(time.strftime(formatstr) + text + '\n')

--- a/payload/Library/Application Support/installapplications/installapplications.py
+++ b/payload/Library/Application Support/installapplications/installapplications.py
@@ -272,6 +272,9 @@ def download_if_needed(item, stage, opts):
         # Time to install.
         iaslog('Hash validated - received: %s expected: %s' % (
                gethash(path), hash))
+        # Fix script permissions.
+        if os.path.splitext(path)[1] != ".pkg":
+            os.chmod(path, 0755)
 
 
 def main():

--- a/payload/Library/Application Support/installapplications/installapplications.py
+++ b/payload/Library/Application Support/installapplications/installapplications.py
@@ -391,9 +391,14 @@ def main():
         # Loop through the items and download/install/run them.
         for item in iajson[stage]:
             # Set the filepath, name and type.
-            path = item['file']
-            name = item['name']
-            type = item['type']
+            try:
+                path = item['file']
+                name = item['name']
+                type = item['type']
+            except KeyError as e:
+                iaslog('Invalid item %s: %s' % (repr(item), str(e)))
+                continue
+            iaslog('%s processing %s %s at %s' % (stage, type, name, path))
             if type == 'package':
                 packageid = item['packageid']
                 version = item['version']

--- a/payload/Library/Application Support/installapplications/installapplications.py
+++ b/payload/Library/Application Support/installapplications/installapplications.py
@@ -223,9 +223,8 @@ def runrootscript(pathname):
         iaslog('Running Script: %s ' % (str(pathname)))
         (out, err) = proc.communicate()
         if err and proc.returncode == 0:
-            iaslog('Running Script: %s ' % (pathname))
-            iaslog('Output from %s on stderr but ran successfully: %s',
-                   pathname, err)
+            iaslog('Output from %s on stderr but ran successfully: %s' %
+                   (pathname, err))
         elif proc.returncode > 0:
             iaslog('Failure running script: ' + str(err))
             return False


### PR DESCRIPTION
* If an `url` is specified for a script, it's downloaded and checksummed just like packages.
* Adds a `--dry-run` option to facilitate testing.
* Adds a `--base-url` option to `generatejson.py` to generate more fleshed out `bootstrap.json` files.
* Minor fixes to error handling.
* The version number has been bumped to 1.1.