### PR TITLE
User Scripts and fix DEPNotify

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ If you would like to open DEPNotify, simply pass the `DEPNotifyPath:` argument t
 installapplications.py --depnotify "DEPNotifyPath: /path/to/DEPNotify.app"
 ```
 
+If you need additional arguments to pass to DEPNotify, add `DEPNotifyArguments:` to the `--depnotify` option.
+
+```
+installapplications.py --depnotify "DEPNotifyPath: /path/to/DEPNotify.app" "DEPNotifyArguments: -munki"
+```
+
 InstallApplications will wait until `stage1` to open DEPNotify as the `prestage` is used for SetupAssistant.
 
 #### DEPNotify LaunchDaemon

--- a/build-info.json
+++ b/build-info.json
@@ -10,5 +10,5 @@
         "timestamp": true
     },
     "suppress_bundle_relocation": true,
-    "version": "1.1"
+    "version": "1.0"
 }

--- a/payload/Library/LaunchAgents/com.erikng.installapplications.plist
+++ b/payload/Library/LaunchAgents/com.erikng.installapplications.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.erikng.installapplications</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/bin/python</string>
+		<string>/Library/Application Support/installapplications/installapplications.py</string>
+		<string>--userscript</string>
+	</array>
+	<key>KeepAlive</key>
+  <dict>
+     <key>PathState</key>
+     <dict>
+       <key>/var/tmp/installapplications/.userscript</key>
+       <true/>
+     </dict>
+  </dict>
+  <key>OnDemand</key>
+  <true/>
+	<key>StandardOutPath</key>
+	<string>/var/tmp/installapplications/installapplications.user.log</string>
+	<key>StandardErrorPath</key>
+	<string>/var/tmp/installapplications/installapplications.user.log</string>
+</dict>
+</plist>

--- a/payload/Library/LaunchDaemons/com.erikng.installapplications.plist
+++ b/payload/Library/LaunchDaemons/com.erikng.installapplications.plist
@@ -12,6 +12,8 @@
 		<string>https://domain.tld</string>
 		<!-- <string>--iapath</string> -->
 		<!-- <string>/Library/Application Support/installapplications</string> -->
+		<!-- <string>--laidentifier</string> -->
+		<!-- <string>com.erikng.installapplications</string> -->
 		<!-- <string>--ldidentifier</string> -->
 		<!-- <string>com.erikng.installapplications</string> -->
 		<!-- <string>--depnotify</string> -->
@@ -20,6 +22,7 @@
 		<!-- <string>Command: Quit: Thanks for using InstallApplications and DEPNotify.</string> -->
 		<!-- <string>Command: WindowStyle: ActivateOnStep</string> -->
 		<!-- <string>DEPNotifyPath: /Applications/Utilities/DEPNotify.app</string> -->
+		<!-- <string>DEPNotifyArguments: -munki</string> -->
 		<!-- <string>--reboot</string> -->
 	</array>
 	<key>RunAtLoad</key>

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -15,27 +15,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Loads the InstallApplications LaunchDaemon
-
+# Loads the InstallApplications LaunchAgent LaunchDaemon
+from SystemConfiguration import SCDynamicStoreCopyConsoleUser
+import os
 import subprocess
 import sys
-import os
 
 
-def launchctld(identifier):
-    try:
-        path = os.path.join('/Library', 'LaunchDaemons', identifier)
-        cmd = ['/bin/launchctl', 'load', path]
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
-        output, err = proc.communicate()
-        return output
-    except KeyError:
-        pass
+def getconsoleuser():
+    cfuser = SCDynamicStoreCopyConsoleUser(None, None, None)
+    return cfuser
+
+
+def launchctl(*arg):
+    # Use *arg to pass unlimited variables to command.
+    cmd = arg
+    run = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, err = run.communicate()
+    return output
 
 
 def main():
-    launchctld('com.erikng.installapplications.plist')
+    lapath = os.path.join('/Library', 'LaunchAgents',
+                          'com.erikng.installapplications.plist')
+    ldpath = os.path.join('/Library', 'LaunchDaemons',
+                          'com.erikng.installapplications.plist')
+    # Fail the install if the admin forgets to change their paths and they
+    # don't exist.
+    for file in [lapath, ldpath]:
+        if os.path.isfile(file):
+            pass
+        else:
+            print 'File does not exist: %s' % file
+            sys.exit(1)
+    currentuseruid = getconsoleuser()
+    launchctl('/bin/launchctl', 'load', ldpath)
+    if (currentuseruid[0] is None or currentuseruid[0] == u'loginwindow'
+            or currentuseruid[0] == u'_mbsetupuser'):
+        pass
+    else:
+        launchctl('/bin/launchctl', 'asuser', str(currentuseruid[1]),
+                  '/bin/launchctl', 'load', lapath)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds support for userscripts. This requires a LaunchAgent to be present on the machine, so added the logic for handling the removal of it via launchctl and the file itself.

This also fixes DEPNotify launching and adds DEPNotify arguments.