### PR TITLE
Move json_data up, before auth headers

### DIFF
--- a/payload/Library/Application Support/installapplications/installapplications.py
+++ b/payload/Library/Application Support/installapplications/installapplications.py
@@ -422,6 +422,13 @@ def main():
     else:
         iaslog('No JSON URL specified!')
         sys.exit(1)
+    
+    # json data for gurl download
+    json_data = {
+            'url': jsonurl,
+            'file': jsonpath,
+            'name': 'Bootstrap.json'
+        }
 
     # Grab auth headers if they exist and update the json_data dict.
     if opts.headers:
@@ -433,13 +440,6 @@ def main():
         os.makedirs(iapath)
     except Exception:
         pass
-
-    # json data for gurl download
-    json_data = {
-            'url': jsonurl,
-            'file': jsonpath,
-            'name': 'Bootstrap.json'
-        }
 
     # If the file doesn't exist, grab it and wait half a second to save.
     while not os.path.isfile(jsonpath):


### PR DESCRIPTION
This PR moves` json_data` before grabbing the auth headers to resolve this traceback I triggered while testing with basic auth:

```
tests-MacBook-Pro:installapplications test$ sudo ./installapplications.py --headers ramdomtext --jsonurl https://domain/dep/bootstrap.json
2017-11-03 14:13:23.699 Python[703:17376] [InstallApplications] Beginning InstallApplications run
2017-11-03 14:13:23.699 Python[703:17376] [InstallApplications] InstallApplications path: /Library/Application Support/installapplications
2017-11-03 14:13:23.699 Python[703:17376] [InstallApplications] InstallApplications LaunchDaemon path: /Library/LaunchDaemons/com.erikng.installapplications.plist
2017-11-03 14:13:23.699 Python[703:17376] [InstallApplications] InstallApplications LaunchAgent path: /Library/LaunchAgents/com.erikng.installapplications.plist
2017-11-03 14:13:23.699 Python[703:17376] [InstallApplications] InstallApplications json path: /Library/Application Support/installapplications/bootstrap.json
Traceback (most recent call last):
  File "./installapplications.py", line 643, in <module>
    main()
  File "./installapplications.py", line 429, in main
    json_data.update({'additional_headers': headers})
UnboundLocalError: local variable 'json_data' referenced before assignment
```