### PR TITLE
Remove preflight stage login window assumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ This stage is designed to only work with a **single rootscript**. This stage is 
 If the preflight script exits 0, InstallApplications will cleanup/remove itself, bypassing the setupassistant and userland stages.
 
 If the preflight script exits 1 or higher, InstallApplications will continue with the bootstrap process.
-
-Please note that the preflight stage will be skipped if InstallApplications is running at the loginwindow.
 #### setupassistant ####
 - Packages/rootscripts that should be prioritized for download/installation _and_ can be installed during SetupAssistant, where no user session is present.
 #### userland ####

--- a/README.md
+++ b/README.md
@@ -223,6 +223,16 @@ The JSON structure is quite simple. You supply the following:
 The following is an example JSON:
 ```json
 {
+  "preflight": [
+    {
+      "donotwait": false,
+      "file": "/Library/Application Support/installapplications/preflight_script.py",
+      "hash": "sha256 hash",
+      "name": "Example Preflight Script",
+      "type": "rootscript",
+      "url": "https://domain.tld/preflight_script.py"
+    }
+  ], 
   "setupassistant": [
     {
       "file": "/Library/Application Support/installapplications/setupassistant.pkg",

--- a/payload/Library/Application Support/installapplications/installapplications.py
+++ b/payload/Library/Application Support/installapplications/installapplications.py
@@ -642,25 +642,17 @@ def main():
                     if depnotifystatus:
                         deplog('Status: Installing: %s' % (name))
                 if stage == 'preflight':
-                    currentuser = getconsoleuser()[0]
-                    # If at the loginwindow, assume new machine.
-                    if (currentuser is None or currentuser == u'loginwindow'
-                            or currentuser == u'_mbsetupuser'):
-                        iaslog('Device is at the loginwindow. Skipping '
-                               'preflight check')
-                        continue
+                    preflightrun = runrootscript(path, donotwait)
+                    if preflightrun:
+                        iaslog('Preflight passed all checks. Skipping run.'
+                                )
+                        userid = str(getconsoleuser()[1])
+                        cleanup(iapath, ialdpath, ldidentifier, ialapath,
+                                laidentifier, userid, reboot)
                     else:
-                        preflightrun = runrootscript(path, donotwait)
-                        if preflightrun:
-                            iaslog('Preflight passed all checks. Skipping run.'
-                                   )
-                            userid = str(getconsoleuser()[1])
-                            cleanup(iapath, ialdpath, ldidentifier, ialapath,
-                                    laidentifier, userid, reboot)
-                        else:
-                            iaslog('Preflight did not pass all checks. '
-                                   'Continuing run.')
-                            continue
+                        iaslog('Preflight did not pass all checks. '
+                                'Continuing run.')
+                        continue
 
                 runrootscript(path, donotwait)
             elif type == 'userscript':


### PR DESCRIPTION
Removes the code that checks for the login window when executing the preflight stage of installapplications.py, and updates the README to reflect this change.

Previously, if the preflight stage were run at the loginwindow, installapplications assumed it was running on a new machine. While this assumption may hold for certain workflows, certain MDM setups or workflows may include sending the InstallApplication MDM command to a device at the loginwindow, which would automatically skip the preflight and it would sit there until next user logged in. This may result in unintended DEPNotify runs and/or logouts/restarts for users with previously deployed and configured machines. This assumption has been removed to instead allow the preflight script to handle this logic.