### PR TITLE
Adding ability to 'require' a pkg be installed on every IA run

### DIFF
--- a/payload/Library/Application Support/installapplications/installapplications.py
+++ b/payload/Library/Application Support/installapplications/installapplications.py
@@ -598,9 +598,14 @@ def main():
             if type == 'package':
                 packageid = item['packageid']
                 version = item['version']
-                # Compare version of package with installed version
+                try:
+                    pkg_required = item['required']
+                except KeyError:
+                    pkg_required = False
+                # Compare version of package with installed version and ensure
+                # pkg is not a required install
                 if LooseVersion(checkreceipt(packageid)) >= LooseVersion(
-                        version):
+                        version) and not pkg_required:
                     iaslog('Skipping %s - already installed.' % (name))
                 else:
                     # Download the package if it isn't already on disk.


### PR DESCRIPTION
This allows an admin to add a key in the bootstrap.json file specifying a package as "required" using a boolean `true` or `false`. Meaning that upon ever IA run, regardless of previous install status, the "required" package should always be (re)installed.

```
   {
      ...
      "version":"1.0",
      "required": false
    },
    {
      ...
      "version":"1.0",
      "required": true
    }

```
If the "required" key is not present, it will be assumed to be False, and the normal checks will ensue.