### PR TITLE
Feature to add plugins for custom item processing and middleware for manipulating HTTP requests before downloading files

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ This optional feature allows you to use third party code, or create your own cod
 ### Details
 
 A Plugin will be imported at runtime as a Python module so the plugin file must be written in Python. However, nothing is stopping you from then calling another executable from Python, so in that sense, you're not limited to Python.
-At the beginning of the InstallApplications run, InstallApplications searches for "plugin*.py", it then tries to import it then looks for the function, "process_item". The item information is then sent through for the plugin to process it in any way needed.
+At the beginning of the InstallApplications run, InstallApplications searches for "plugin*.py", it then tries to import it and then looks for the function, "process_item". The item information is then sent through for the plugin to process it in any way needed.
 
 You may only use one plugin file. If you have more than one plugin file you **will** have unpredictable results
 
@@ -368,6 +368,149 @@ _Example function_
     print '***Processing: %s' % item.get('name')
     return
 ```
-This is a basic example: InstallApplications sends the defined item information, we print the item name and then complete the function with a simple return.
+This is a basic example: InstallApplications sends the defined item information, we print the item name and then complete the function with a return.
 
 `process_item` has a single input parameter: the item dictionary (defined in the bootstrap.json file). It does not need to return anything back, it just needs to break the function in some way so that InstallApplications can continue to the next item.
+
+
+## Middleware
+This optional feature allows you to use third party code, or create your own code to manipulate InstallApplication's HTTP requests. The primary use case for this feature is to provide interaction with APIs, although it is not limited to that. Middleware is activated by the presence of a Python file. If it's there it gets called, if it's not it won't, it's as simple as that.
+
+
+### Details
+
+Middleware gets imported at runtime as a Python module so the middleware file **must** be written in Python. Nothing is stopping you from then calling another executable from Python, so in that sense, you're not limited to Python.  
+At the beginning of the InstallApplications run, InstallApplications searches for "middleware*.py", it then tries to import it and then looks for the function, "process_request_options". The options are then sent through, examined, changed, or not, before heading to the server.
+
+You may only use one middleware file. If you have more then one of middleware file you **will** have unpredictable results.
+
+#### Requirements
+
+For the middleware to work, you will need the following:
+
+##### Filename
+InstallApplications is looking for files the start with "middleware" and end with ".py".  
+Examples of good and bad middleware filenames:  
+- middleware.py👍
+- ~~middleware~~👎
+- ~~my_middleware.py~~👎
+- middleware_cloudfoo.py👍
+
+##### Location
+The middleware file must live in the same folder as InstallApplications (/Library/Application Support/InstallApplications/).
+
+##### Permissions
+Root must be the owner of the file and be able to read it. Since it's imported by Python, the executable part isn't necessary. It's important to note that if you plan on storing sensitive information inside you should restrict access.
+```bash
+sudo chown root /Library/Application\ Support/InstallApplications/middleware*.py
+sudo chmod 600 /Library/Application\ Support/InstallApplications/middleware*.py
+```
+
+##### The "process_request_options" function
+This is the function that InstallApplications is looking for. Think of it as the "main" function for the middleware. If InstallApplications doesn't find this function it will abandon the middleware, and continue on as if it wasn't there.   
+
+_Example function_
+ ```python
+ def process_request_options(options):
+    print '***Requesting: %s' % options.get('url')
+    return options
+```
+This is a basic example: InstallApplications sends the request options, we print the requested url and then return the options unchanged.
+`process_request_options` has a single input parameter: the options dictionary (described in detail below). It must return the options dictionary (possibly modified).
+
+
+#### Middleware examples
+##### Query Parameters
+_Query Params Example_
+```python
+from urllib import urlencode
+
+QUERY_PARAMS={'username': 'apiuser', 'password': 'secret password'}
+
+def encode_params(data):
+    """Encode parameters in a piece of data.
+    Will successfully encode parameters when passed as a dict or a list of
+    2-tuples. Order is retained if data is a list of 2-tuples but arbitrary
+    if parameters are supplied as a dict.
+    """
+    result = []
+
+    for k, vs in QUERY_PARAMS.items():
+        if isinstance(vs, basestring) or not hasattr(vs, '__iter__'):
+            vs = [vs]
+        for v in vs:
+            if v is not None:
+                result.append(
+                    (k.encode('utf-8') if isinstance(k, str) else k,
+                     v.encode('utf-8') if isinstance(v, str) else v))
+    return urlencode(result, doseq=True)
+
+
+def process_request_options(options):
+    url = options.get('url')
+    if 'swscan.apple.com' not in url:
+        print 'URL Before: %s' % options.get('url')
+        #concat url and query string
+        options['url'] = options['url'] + '?' + encode_params(QUERY_PARAMS)
+        print 'URL After: %s' % options.get('url')
+    return options
+```
+In the example above we are joining the URL from InstallApplications and query string together.
+
+###### Before:   
+`http://ias.example.com/catalogs/production`
+
+###### After:
+`http://ias.example.com/catalogs/production?username=apiuser&password=secret+password`
+
+
+##### Headers
+
+_Headers Example_
+```python
+HEADERS = {'api_key': '123_IAM_A_KEY', 'api_secret': 'SECRETKEY'}
+
+
+def process_request_options(options):
+    url = options.get('url')
+    if 'swscan.apple.com' not in url:
+        print 'Headers before: %s' % options['additional_headers']
+        # Merge headers with InstallApplications
+        options['additional_headers'].update(HEADERS)
+        print 'Headers after: %s' % options['additional_headers']
+    return options
+```
+Since the 'additional_headers' key is a dictionary it is easy for us to update retaining the `User-Agent` and `Authorization` headers.
+
+###### Before:
+`{u'Authorization': u'Basic bXVua2k6WUhuUXhWWFFh==', 'User-Agent': u'installapplications/1.2.1 Darwin/15.4.0'}`  
+
+###### After:
+`{'api_secret': 'SECRETKEY', 'api_key': '123_IAM_A_KEY', u'Authorization': u'Basic bXVua2k6WUhuUXhWWFFh==', 'User-Agent': u'installapplications/1.2.1 Darwin/15.4.0'}`
+
+
+
+##### Available options
+These are all the options that can be changed with the middleware. Most of the time you'll only be interested in the **url** and the **additional_headers**
+
+| Key | Type | Description  | Default Value |
+|-----|------|--------------|---------------|
+| url    | String | The 'url' you are requesting. ||
+| additional_headers | Dictionary | These are the HTTP headers that are going in the get request. [List of HTTP header fields](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields) | `{'User-Agent': u'installapplications/%IAS_VER% Darwin/%OS_VER%'}` |
+| resume | Boolean | If `True`, Gurl will attempt to resume an interrupted download. _**You should probably leave this alone._ | `False` |
+| follow_redirects | String | By default, InstallApplications will not follow redirects that are returned by the web server. The `follow_redirects` preference defines whether InstallApplications should follow all redirects or only redirect to HTTPS URLs. The possible values for `follow_redirects` are listed below | `None` |
+* ``none`` - This is the default and is the same as InstallApplications's original behavior. No redirects are followed.
+* ``https`` - Only redirects to URLs using HTTPS are followed. Redirects to HTTP URLs are not followed.
+* ``all`` - Redirects to both HTTP and HTTPS URLs are followed.
+
+### Middleware modules
+
+Here are some middleware modules to try:
+
+
+| Provider | URL |
+| -------- | --- |
+| Amazon CloudFront | https://github.com/AaronBurchfield/CloudFront-Middleware |
+| Amazon s3 | https://github.com/waderobson/s3-auth |
+| Backblaze B2 | https://github.com/sphen13/B2-Middleware |
+| Google Cloud storage | https://github.com/waderobson/gcs-auth |


### PR DESCRIPTION
This is a straight-up port of Middleware from Munki - https://github.com/munki/munki/blob/v3.3.1/code/client/munkilib/fetch.py#L73

Future enhancements would be to add the actual middleware-like functionality for the gurl download. Resulting in a plugin + middleware combo if desired.

But the main use case for me: some items in Bootstrap.json I will define with type:plugin, with a name (for DEPNotify), and AirWatch app ID. Then the VMware AirWatch plugin (in development) will make the necessary API calls to push the app via the various AirWatch Agent software distribution mechanisms. Future enhancements - the plugin will have the ability to take in a Profile ID, to orchestrate the order of profile installs if needed - for example, downloading a VPN software before pushing a script/profile to bind the machine.