### PR TITLE
generatejson absolute or relative paths

### DIFF
--- a/generatejson.py
+++ b/generatejson.py
@@ -66,6 +66,9 @@ def extractpkginfo(filename):
     if not os.path.isfile(filename):
         return
     else:
+        if not os.path.isabs(filename):
+            filename = os.path.join(cwd, filename)
+
         tmpFolder = tempfile.mkdtemp()
         os.chdir(tmpFolder)
         # need to get path from BOM


### PR DESCRIPTION
Code for finding pkg info would sometimes bail if it was passed relative paths (os.chdir too early). Added check to make the filename path absolute if it is not already.