### PR TITLE
Make baseurl work again, fix relative paths

### DIFF
--- a/generatejson.py
+++ b/generatejson.py
@@ -66,6 +66,9 @@ def extractpkginfo(filename):
     if not os.path.isfile(filename):
         return
     else:
+        if not os.path.isabs(filename):
+            filename = os.path.join(cwd, filename)
+
         tmpFolder = tempfile.mkdtemp()
         os.chdir(tmpFolder)
         # need to get path from BOM


### PR DESCRIPTION
Adds a check for if the path passed to the pkginfo function is absolute or not. This will let people pass relative paths to the function.

A few changes to make base URL actually work:
1) change nargs to *, allows less than 6 metavars to be passed for each item arg
2) add a try/except block to check for the two absolutely mandatory all the time args (name and path)
3) convert some of the if/else statements to try/except to support nonexistent keys that aren't mandatory any more, this will allow us to enforce defaults as listed in the top of the file for stage and type
4) add a try/except around script-do-not-wait along with error messaging to catch if someone forgets do not wait (which we may want to just make default to false, not sure... input?)
