### PR TITLE
WIP: Python3 compatbility

### DIFF
--- a/payload/Library/Application Support/installapplications/gurl.py
+++ b/payload/Library/Application Support/installapplications/gurl.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Copyright 2009-2017 Greg Neagle.
+# Copyright 2009-2019 Greg Neagle.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
@@ -18,23 +18,39 @@ gurl.py
 
 Created by Greg Neagle on 2013-11-21.
 Modified in Feb 2016 to add support for NSURLSession.
+Updated June 2019 for compatibility with Python 3 and PyObjC 5.1.2+
 
 curl replacement using NSURLConnection and friends
+
+Tested with PyObjC 2.5.1 (inlcuded with macOS)
+and with PyObjC 5.2b1. Should also work with PyObjC 5.1.2.
+May fail with other versions of PyObjC due to issues with completion handler
+signatures.
 """
+from __future__ import absolute_import, print_function
 
 import os
 import xattr
-from urlparse import urlparse
+
+try:
+    # Python 2
+    from urlparse import urlparse
+except ImportError:
+    # Python 3
+    from urllib.parse import urlparse
+
 
 # builtin super doesn't work with Cocoa classes in recent PyObjC releases.
+# pylint: disable=redefined-builtin,no-name-in-module
 from objc import super
+# pylint: enable=redefined-builtin,no-name-in-module
 
 # PyLint cannot properly find names inside Cocoa libraries, so issues bogus
 # No name 'Foo' in module 'Bar' warnings. Disable them.
 # pylint: disable=E0611
 
 
-from Foundation import (NSBundle, NSRunLoop, NSDate,
+from Foundation import (NSBundle, NSRunLoop, NSData, NSDate,
                         NSObject, NSURL, NSURLConnection,
                         NSMutableURLRequest,
                         NSURLRequestReloadIgnoringLocalCacheData,
@@ -79,17 +95,23 @@ if NSURLSESSION_AVAILABLE:
     # define a helper function for block callbacks
     import ctypes
     import objc
-    _objc_so = ctypes.cdll.LoadLibrary(
-        os.path.join(objc.__path__[0], '_objc.so'))
-    PyObjCMethodSignature_WithMetaData = (
-        _objc_so.PyObjCMethodSignature_WithMetaData)
-    PyObjCMethodSignature_WithMetaData.restype = ctypes.py_object
+    CALLBACK_HELPER_AVAILABLE = True
+    try:
+        _objc_so = ctypes.cdll.LoadLibrary(
+            os.path.join(objc.__path__[0], '_objc.so'))
+    except OSError:
+        # could not load _objc.so
+        CALLBACK_HELPER_AVAILABLE = False
+    else:
+        PyObjCMethodSignature_WithMetaData = (
+            _objc_so.PyObjCMethodSignature_WithMetaData)
+        PyObjCMethodSignature_WithMetaData.restype = ctypes.py_object
 
-    def objc_method_signature(signature_str):
-        '''Return a PyObjCMethodSignature given a call signature in string
-        format'''
-        return PyObjCMethodSignature_WithMetaData(
-            ctypes.create_string_buffer(signature_str), None, False)
+        def objc_method_signature(signature_str):
+            '''Return a PyObjCMethodSignature given a call signature in string
+            format'''
+            return PyObjCMethodSignature_WithMetaData(
+                ctypes.create_string_buffer(signature_str), None, False)
 
 # pylint: enable=E0611
 
@@ -175,7 +197,7 @@ class Gurl(NSObject):
         '''Set up our Gurl object'''
         self = super(Gurl, self).init()
         if not self:
-            return
+            return None
 
         self.follow_redirects = options.get('follow_redirects', False)
         self.ignore_system_proxy = options.get('ignore_system_proxy', False)
@@ -228,7 +250,7 @@ class Gurl(NSObject):
                 request.setValue_forHTTPHeaderField_(value, header)
         # does the file already exist? See if we can resume a partial download
         if os.path.isfile(self.destination_path):
-            stored_data = self.get_stored_headers()
+            stored_data = self.getStoredHeaders()
             if (self.can_resume and 'expected-length' in stored_data and
                     ('last-modified' in stored_data or 'etag' in stored_data)):
                 # we have a partial file and we're allowed to resume
@@ -237,7 +259,7 @@ class Gurl(NSObject):
                 byte_range = 'bytes=%s-' % local_filesize
                 request.setValue_forHTTPHeaderField_(byte_range, 'Range')
         if self.download_only_if_changed and not self.resume:
-            stored_data = self.cache_data or self.get_stored_headers()
+            stored_data = self.cache_data or self.getStoredHeaders()
             if 'last-modified' in stored_data:
                 request.setValue_forHTTPHeaderField_(
                     stored_data['last-modified'], 'if-modified-since')
@@ -245,8 +267,8 @@ class Gurl(NSObject):
                 request.setValue_forHTTPHeaderField_(
                     stored_data['etag'], 'if-none-match')
         if NSURLSESSION_AVAILABLE:
-            configuration = \
-                NSURLSessionConfiguration.defaultSessionConfiguration()
+            configuration = (
+                NSURLSessionConfiguration.defaultSessionConfiguration())
 
             # optional: ignore system http/https proxies (10.9+ only)
             if self.ignore_system_proxy is True:
@@ -254,13 +276,13 @@ class Gurl(NSObject):
                     {kCFNetworkProxiesHTTPEnable: False,
                      kCFNetworkProxiesHTTPSEnable: False})
 
-            # set minumum supported TLS protocol (defaults to TLS1)
+            # set minimum supported TLS protocol (defaults to TLS1)
             configuration.setTLSMinimumSupportedProtocol_(
                 self.minimum_tls_protocol)
 
-            self.session = \
+            self.session = (
                 NSURLSession.sessionWithConfiguration_delegate_delegateQueue_(
-                    configuration, self, None)
+                    configuration, self, None))
             self.task = self.session.dataTaskWithRequest_(request)
             self.task.resume()
         else:
@@ -286,41 +308,44 @@ class Gurl(NSObject):
             NSDate.dateWithTimeIntervalSinceNow_(.1))
         return self.done
 
-    def get_stored_headers(self):
+    def getStoredHeaders(self):
         '''Returns any stored headers for self.destination_path'''
         # try to read stored headers
         try:
-            stored_plist_str = xattr.getxattr(
+            stored_plist_bytestr = xattr.getxattr(
                 self.destination_path, self.GURL_XATTR)
         except (KeyError, IOError):
             return {}
-        data = buffer(stored_plist_str)
-        dataObject, plistFormat, error = (
+        data = NSData.dataWithBytes_length_(
+            stored_plist_bytestr, len(stored_plist_bytestr))
+        dataObject, _plistFormat, error = (
             NSPropertyListSerialization.
             propertyListFromData_mutabilityOption_format_errorDescription_(
                 data, NSPropertyListMutableContainersAndLeaves, None, None))
         if error:
             return {}
-        else:
-            return dataObject
+        return dataObject
 
-    def store_headers(self, headers):
+    def storeHeaders_(self, headers):
         '''Store dictionary data as an xattr for self.destination_path'''
         plistData, error = (
             NSPropertyListSerialization.
             dataFromPropertyList_format_errorDescription_(
                 headers, NSPropertyListXMLFormat_v1_0, None))
         if error:
-            string = ''
+            byte_string = b''
         else:
-            string = str(plistData)
+            try:
+                byte_string = bytes(plistData)
+            except NameError:
+                byte_string = str(plistData)
         try:
-            xattr.setxattr(self.destination_path, self.GURL_XATTR, string)
-        except IOError, err:
+            xattr.setxattr(self.destination_path, self.GURL_XATTR, byte_string)
+        except IOError as err:
             self.log('Could not store metadata to %s: %s'
                      % (self.destination_path, err))
 
-    def normalize_header_dict(self, a_dict):
+    def normalizeHeaderDict_(self, a_dict):
         '''Since HTTP header names are not case-sensitive, we normalize a
         dictionary of HTTP headers by converting all the key names to
         lower case'''
@@ -349,15 +374,13 @@ class Gurl(NSObject):
         don\'t attempt to resume the download next time'''
         if str(self.status).startswith('2'):
             # remove the expected-size from the stored headers
-            headers = self.get_stored_headers()
+            headers = self.getStoredHeaders()
             if 'expected-length' in headers:
                 del headers['expected-length']
-                self.store_headers(headers)
+                self.storeHeaders_(headers)
 
-    def URLSession_task_didCompleteWithError_(self, session, task, error):
+    def URLSession_task_didCompleteWithError_(self, _session, _task, error):
         '''NSURLSessionTaskDelegate method.'''
-        # we don't actually use the session or task arguments, so
-        # pylint: disable=W0613
         if self.destination and self.destination_path:
             self.destination.close()
             self.removeExpectedSizeFromStoredHeaders()
@@ -365,23 +388,17 @@ class Gurl(NSObject):
             self.recordError_(error)
         self.done = True
 
-    def connection_didFailWithError_(self, connection, error):
+    def connection_didFailWithError_(self, _connection, error):
         '''NSURLConnectionDelegate method
         Sent when a connection fails to load its request successfully.'''
-        # we don't actually use the connection argument, so
-        # pylint: disable=W0613
         self.recordError_(error)
         self.done = True
         if self.destination and self.destination_path:
             self.destination.close()
 
-    def connectionDidFinishLoading_(self, connection):
+    def connectionDidFinishLoading_(self, _connection):
         '''NSURLConnectionDataDelegate method
         Sent when a connection has finished loading successfully.'''
-
-        # we don't actually use the connection argument, so
-        # pylint: disable=W0613
-
         self.done = True
         if self.destination and self.destination_path:
             self.destination.close()
@@ -400,7 +417,7 @@ class Gurl(NSObject):
             # Headers and status code only available for HTTP/S transfers
             self.status = response.statusCode()
             self.headers = dict(response.allHeaderFields())
-            normalized_headers = self.normalize_header_dict(self.headers)
+            normalized_headers = self.normalizeHeaderDict_(self.headers)
             if 'last-modified' in normalized_headers:
                 download_data['last-modified'] = normalized_headers[
                     'last-modified']
@@ -414,7 +431,7 @@ class Gurl(NSObject):
         if not self.destination and self.destination_path:
             if self.status == 206 and self.resume:
                 # 206 is Partial Content response
-                stored_data = self.get_stored_headers()
+                stored_data = self.getStoredHeaders()
                 if (not stored_data or
                         stored_data.get('etag') != download_data.get('etag') or
                         stored_data.get('last-modified') != download_data.get(
@@ -444,38 +461,50 @@ class Gurl(NSObject):
                 self.bytesReceived = local_filesize
                 self.expectedLength += local_filesize
                 # open file for append
-                self.destination = open(self.destination_path, 'a')
+                self.destination = open(self.destination_path, 'ab')
 
             elif str(self.status).startswith('2'):
                 # not resuming, just open the file for writing
-                self.destination = open(self.destination_path, 'w')
+                self.destination = open(self.destination_path, 'wb')
                 # store some headers with the file for use if we need to resume
-                # the downloadand for future checking if the file on the server
+                # the download and for future checking if the file on the server
                 # has changed
-                self.store_headers(download_data)
+                self.storeHeaders_(download_data)
+
         if completionHandler:
             # tell the session task to continue
             completionHandler(NSURLSessionResponseAllow)
 
     def URLSession_dataTask_didReceiveResponse_completionHandler_(
-            self, session, task, response, completionHandler):
+            self, _session, _task, response, completionHandler):
         '''NSURLSessionDataDelegate method'''
-        # we don't actually use the session or task arguments, so
-        # pylint: disable=W0613
-        completionHandler.__block_signature__ = objc_method_signature('v@i')
+        if CALLBACK_HELPER_AVAILABLE:
+            completionHandler.__block_signature__ = objc_method_signature(b'v@i')
         self.handleResponse_withCompletionHandler_(response, completionHandler)
 
-    def connection_didReceiveResponse_(self, connection, response):
+    def connection_didReceiveResponse_(self, _connection, response):
         '''NSURLConnectionDataDelegate delegate method
         Sent when the connection has received sufficient data to construct the
         URL response for its request.'''
-        # we don't actually use the connection argument, so
-        # pylint: disable=W0613
         self.handleResponse_withCompletionHandler_(response, None)
 
     def handleRedirect_newRequest_withCompletionHandler_(
             self, response, request, completionHandler):
         '''Handle the redirect request'''
+        def allowRedirect():
+            '''Allow the redirect'''
+            if completionHandler:
+                completionHandler(request)
+                return None
+            return request
+
+        def denyRedirect():
+            '''Deny the redirect'''
+            if completionHandler:
+                completionHandler(None)
+            return None
+
+        newURL = request.URL().absoluteString()
         if response is None:
             # the request has changed the NSURLRequest in order to standardize
             # its format, for example, changing a request for
@@ -489,16 +518,12 @@ class Gurl(NSObject):
             # all in this scenario, unlike NSConnectionDelegate method
             # connection:willSendRequest:redirectResponse:
             # we'll leave this here anyway in case we're wrong about that
-            if completionHandler:
-                completionHandler(request)
-                return
-            else:
-                return request
+            self.log('Allowing redirect to: %s' % newURL)
+            return allowRedirect()
         # If we get here, it appears to be a real redirect attempt
         # Annoyingly, we apparently can't get access to the headers from the
         # site that told us to redirect. All we know is that we were told
         # to redirect and where the new location is.
-        newURL = request.URL().absoluteString()
         self.redirection.append([newURL, dict(response.allHeaderFields())])
         newParsedURL = urlparse(newURL)
         # This code was largely based on the work of Andreas Fuchs
@@ -506,65 +531,47 @@ class Gurl(NSObject):
         if self.follow_redirects is True or self.follow_redirects == 'all':
             # Allow the redirect
             self.log('Allowing redirect to: %s' % newURL)
-            if completionHandler:
-                completionHandler(request)
-                return
-            else:
-                return request
+            return allowRedirect()
         elif (self.follow_redirects == 'https'
               and newParsedURL.scheme == 'https'):
             # Once again, allow the redirect
             self.log('Allowing redirect to: %s' % newURL)
-            if completionHandler:
-                completionHandler(request)
-                return
-            else:
-                return request
-        else:
-            # If we're down here either the preference was set to 'none',
-            # the url we're forwarding on to isn't https or follow_redirects
-            # was explicitly set to False
-            self.log('Denying redirect to: %s' % newURL)
-            if completionHandler:
-                completionHandler(None)
-                return
-            else:
-                return None
+            return allowRedirect()
+        # If we're down here either the preference was set to 'none',
+        # the url we're forwarding on to isn't https or follow_redirects
+        # was explicitly set to False
+        self.log('Denying redirect to: %s' % newURL)
+        return denyRedirect()
 
+    # we don't control the API, so
+    # pylint: disable=too-many-arguments
     def URLSession_task_willPerformHTTPRedirection_newRequest_completionHandler_(
-            self, session, task, response, request, completionHandler):
+            self, _session, _task, response, request, completionHandler):
         '''NSURLSessionTaskDelegate method'''
-        # we don't actually use the session or task arguments, so
-        # pylint: disable=W0613
         self.log(
             'URLSession_task_willPerformHTTPRedirection_newRequest_'
             'completionHandler_')
-        completionHandler.__block_signature__ = objc_method_signature('v@@')
+        if CALLBACK_HELPER_AVAILABLE:
+            completionHandler.__block_signature__ = objc_method_signature(b'v@@')
         self.handleRedirect_newRequest_withCompletionHandler_(
             response, request, completionHandler)
+    # pylint: enable=too-many-arguments
 
     def connection_willSendRequest_redirectResponse_(
-            self, connection, request, response):
+            self, _connection, request, response):
         '''NSURLConnectionDataDelegate method
-        Sent when the connection determines that it must change URLs in order to
-        continue loading a request.'''
-
-        # we don't actually use the connection argument, so
-        # pylint: disable=W0613
+        Sent when the connection determines that it must change URLs in order
+        to continue loading a request.'''
         self.log('connection_willSendRequest_redirectResponse_')
         return self.handleRedirect_newRequest_withCompletionHandler_(
             response, request, None)
 
     def connection_canAuthenticateAgainstProtectionSpace_(
-            self, connection, protectionSpace):
+            self, _connection, protectionSpace):
         '''NSURLConnection delegate method
         Sent to determine whether the delegate is able to respond to a
         protection space’s form of authentication.
         Deprecated in 10.10'''
-
-        # we don't actually use the connection argument, so
-        # pylint: disable=W0613
-
         # this is not called in 10.5.x.
         self.log('connection_canAuthenticateAgainstProtectionSpace_')
         if protectionSpace:
@@ -642,59 +649,55 @@ class Gurl(NSObject):
                             challenge)
 
     def connection_willSendRequestForAuthenticationChallenge_(
-            self, connection, challenge):
+            self, _connection, challenge):
         '''NSURLConnection delegate method
         Tells the delegate that the connection will send a request for an
         authentication challenge. New in 10.7.'''
-        # we don't actually use the connection argument, so
-        # pylint: disable=W0613
         self.log('connection_willSendRequestForAuthenticationChallenge_')
         self.handleChallenge_withCompletionHandler_(challenge, None)
 
     def URLSession_task_didReceiveChallenge_completionHandler_(
-            self, session, task, challenge, completionHandler):
+            self, _session, _task, challenge, completionHandler):
         '''NSURLSessionTaskDelegate method'''
-        # we don't actually use the session or task arguments, so
-        # pylint: disable=W0613
-        completionHandler.__block_signature__ = objc_method_signature('v@i@')
+        if CALLBACK_HELPER_AVAILABLE:
+            completionHandler.__block_signature__ = objc_method_signature(b'v@i@')
         self.log('URLSession_task_didReceiveChallenge_completionHandler_')
         self.handleChallenge_withCompletionHandler_(
             challenge, completionHandler)
 
     def connection_didReceiveAuthenticationChallenge_(
-            self, connection, challenge):
+            self, _connection, challenge):
         '''NSURLConnection delegate method
         Sent when a connection must authenticate a challenge in order to
         download its request. Deprecated in 10.10'''
-        # we don't actually use the connection argument, so
-        # pylint: disable=W0613
         self.log('connection_didReceiveAuthenticationChallenge_')
         self.handleChallenge_withCompletionHandler_(challenge, None)
 
     def handleReceivedData_(self, data):
         '''Handle received data'''
         if self.destination:
-            self.destination.write(str(data))
+            self.destination.write(data)
         else:
-            self.log(str(data).decode('UTF-8'))
+            try:
+                self.log(str(data))
+            except Exception:
+                pass
         self.bytesReceived += len(data)
         if self.expectedLength != NSURLResponseUnknownLength:
+            # pylint: disable=old-division
             self.percentComplete = int(
                 float(self.bytesReceived)/float(self.expectedLength) * 100.0)
+            # pylint: enable=old-division
 
-    def URLSession_dataTask_didReceiveData_(self, session, task, data):
+    def URLSession_dataTask_didReceiveData_(self, _session, _task, data):
         '''NSURLSessionDataDelegate method'''
-        # we don't actually use the session or task arguments, so
-        # pylint: disable=W0613
         self.handleReceivedData_(data)
 
-    def connection_didReceiveData_(self, connection, data):
+    def connection_didReceiveData_(self, _connection, data):
         '''NSURLConnectionDataDelegate method
         Sent as a connection loads data incrementally'''
-        # we don't actually use the connection argument, so
-        # pylint: disable=W0613
         self.handleReceivedData_(data)
 
 
 if __name__ == '__main__':
-    print 'This is a library of support tools for the Munki Suite.'
+    print('This is a library of support tools for the Munki Suite.')

--- a/payload/Library/Application Support/installapplications/installapplications.py
+++ b/payload/Library/Application Support/installapplications/installapplications.py
@@ -308,7 +308,7 @@ def download_if_needed(item, stage, type, opts, depnotifystatus):
         # Fix script permissions.
         if os.path.splitext(path)[1] != ".pkg":
             os.chmod(path, 0755)
-        if type is 'userscript':
+        if type == 'userscript':
             os.chmod(path, 0777)
 
 

--- a/payload/Library/Application Support/installapplications/installapplications.py
+++ b/payload/Library/Application Support/installapplications/installapplications.py
@@ -677,15 +677,14 @@ def main():
                 if stage == 'preflight':
                     preflightrun = runrootscript(path, donotwait)
                     if preflightrun:
-                        iaslog('Preflight passed all checks. Skipping run.'
-                                )
+                        iaslog('Preflight passed all checks. Skipping run.')
                         userid = str(getconsoleuser()[1])
                         # Do not allow a reboot for passed preflights
                         cleanup(iapath, ialdpath, ldidentifier, ialapath,
                                 laidentifier, userid, False)
                     else:
                         iaslog('Preflight did not pass all checks. '
-                                'Continuing run.')
+                               'Continuing run.')
                         continue
 
                 runrootscript(path, donotwait)

--- a/payload/Library/Application Support/installapplications/installapplications.py
+++ b/payload/Library/Application Support/installapplications/installapplications.py
@@ -25,6 +25,8 @@
 # https://github.com/munki/munki
 # Notice a pattern?
 
+from __future__ import print_function
+
 from distutils.version import LooseVersion
 from Foundation import NSLog
 from SystemConfiguration import SCDynamicStoreCopyConsoleUser
@@ -400,7 +402,7 @@ def main():
     if opts.jsonurl:
         jsonurl = opts.jsonurl
         if not g_dry_run and (os.getuid() != 0):
-            print 'InstallApplications requires root!'
+            print('InstallApplications requires root!')
             sys.exit(1)
     else:
         if opts.userscript:

--- a/payload/Library/Application Support/installapplications/installapplications.py
+++ b/payload/Library/Application Support/installapplications/installapplications.py
@@ -661,7 +661,7 @@ def main():
                             if depnotifystatus:
                                 deplog('Status: Installing: %s' % (name))
                     # Install the package
-                    installerstatus = installpackage(item['file'])
+                    installpackage(item['file'])
             elif type == 'rootscript':
                 if 'url' in item:
                     download_if_needed(item, stage, type, opts,

--- a/payload/Library/Application Support/installapplications/installapplications.py
+++ b/payload/Library/Application Support/installapplications/installapplications.py
@@ -307,9 +307,9 @@ def download_if_needed(item, stage, type, opts, depnotifystatus):
                gethash(path), hash))
         # Fix script permissions.
         if os.path.splitext(path)[1] != ".pkg":
-            os.chmod(path, 0755)
+            os.chmod(path, 0o755)
         if type == 'userscript':
-            os.chmod(path, 0777)
+            os.chmod(path, 0o777)
 
 
 def touch(path):
@@ -318,7 +318,7 @@ def touch(path):
         proc = subprocess.Popen(touchfile, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
         touchfileoutput, err = proc.communicate()
-        os.chmod(path, 0777)
+        os.chmod(path, 0o777)
         return touchfileoutput
     except Exception:
         return None
@@ -452,7 +452,7 @@ def main():
         for path in [iauserscriptpath, iatmppath]:
             if not os.path.isdir(path):
                 os.makedirs(path)
-                os.chmod(path, 0777)
+                os.chmod(path, 0o777)
 
     # In rare cases, the user log file will be owned by _mbsetupuser causing
     # everything to hang for the user script to finish. Either way, make it
@@ -461,9 +461,9 @@ def main():
                                  'installapplications.user.log')
     if not os.path.isfile(user_log_path):
         touch(user_log_path)
-        os.chmod(user_log_path, 0777)
+        os.chmod(user_log_path, 0o777)
     else:
-        os.chmod(user_log_path, 0777)
+        os.chmod(user_log_path, 0o777)
 
     # Skip these triggers as they either go at the end of the run or
     # our custom to IAs
@@ -580,7 +580,7 @@ def main():
                         mlogfile = os.path.join(mlogpath,
                                                 'ManagedSoftwareUpdate.log')
                         if not os.path.isdir(mlogpath):
-                            os.makedirs(mlogpath, 0755)
+                            os.makedirs(mlogpath, 0o755)
                         if not os.path.isfile(mlogfile):
                             touch(mlogfile)
                     if len(depnotifyarguments) >= 2:
@@ -606,7 +606,7 @@ def main():
                 depnotifyscript += '\n' + 'subprocess.call(depnotifycmd)'
                 with open(depnotifyscriptpath, 'wb') as f:
                     f.write(depnotifyscript)
-                os.chmod(depnotifyscriptpath, 0777)
+                os.chmod(depnotifyscriptpath, 0o777)
                 touch(userscripttouchpath)
                 while os.path.isfile(userscripttouchpath):
                     iaslog('Waiting for DEPNotify script to complete')

--- a/payload/Library/Application Support/installapplications/installapplications.py
+++ b/payload/Library/Application Support/installapplications/installapplications.py
@@ -69,8 +69,8 @@ def pkgregex(pkgpath):
         # capture everything after last / in the pkg filepath
         pkgname = re.compile(r"[^/]+$").search(pkgpath).group(0)
         return pkgname
-    except AttributeError, IndexError:
-        return packagepath
+    except (AttributeError, IndexError) as e:
+        return pkgpath
 
 
 def installpackage(packagepath):

--- a/payload/Library/Application Support/installapplications/installapplications.py
+++ b/payload/Library/Application Support/installapplications/installapplications.py
@@ -27,9 +27,6 @@
 
 from __future__ import print_function
 
-from distutils.version import LooseVersion
-from Foundation import NSLog
-from SystemConfiguration import SCDynamicStoreCopyConsoleUser
 import hashlib
 import json
 import optparse
@@ -41,9 +38,15 @@ import subprocess
 import sys
 import time
 import urllib
-sys.path.append('/usr/local/installapplications')
+from distutils.version import LooseVersion
+
+from Foundation import NSLog
+
 # PEP8 can really be annoying at times.
 import gurl  # noqa
+from SystemConfiguration import SCDynamicStoreCopyConsoleUser
+
+sys.path.append('/usr/local/installapplications')
 
 
 g_dry_run = False


### PR DESCRIPTION
**Not tested**. ~~I did not manage to figure out how to import `SystemConfiguration` in python3 with py-objc yet.~~

- `gurl.py` is updated to current version as in `munki-dev` branch.
- Python3 compatibility changes in `installapplications.py`.

Update:

I managed to install `pyobjc-framework-SystemConfiguration` for my MacPorts Python3 via PIP. `installapplications.py`  now displays the help.
Next step should probably be to build [relocatable-python](https://github.com/gregneagle/relocatable-python) including necessary libraries and make `installapplications.py` use it. ~100 MB extra for our bootstrap package... yay.