### PR TITLE
TypeError bug in python3

### DIFF
--- a/generatejson.py
+++ b/generatejson.py
@@ -49,15 +49,18 @@ def getpkginfopath(filename):
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)
     (bom, err) = proc.communicate()
-    bom = bom.strip().split('\n')
-    if proc.returncode == 0:
+    
+    try:
+        # Decode the byte stream and convert to list
+        bom = bom.decode("utf-8").split()
         for entry in bom:
-            if entry.startswith('PackageInfo'):
+            if entry.startswith("PackageInfo"):
                 return entry
-            elif entry.endswith('.pkg/PackageInfo'):
+            elif entry.endswith(".pkg/PackageInfo"):
                 return entry
-    else:
+    except Exception as e:
         print("Error: %s while extracting BOM for %s" % (err, filename))
+        SystemExit("Error: %s" % e)
 
 
 def extractpkginfo(filename):
@@ -94,8 +97,10 @@ def getpkginfo(filename):
         dom = minidom.parse(pkgInfoPath)
         pkgRefs = dom.getElementsByTagName('pkg-info')
         for ref in pkgRefs:
-            pkgId = ref.attributes['identifier'].value.encode('UTF-8')
-            pkgVersion = ref.attributes['version'].value.encode('UTF-8')
+            # Removed UTF-8 encoding
+            pkgId = ref.attributes["identifier"].value
+            # Removed UTF-8 encoding
+            pkgVersion = ref.attributes["version"].value
             return pkgId, pkgVersion
 
 


### PR DESCRIPTION
TypeError: a bytes-like object is required, not 'str'

Receive this error when attempting to generate the bootstrap.json file on python 3.8.1 and 3.7.6. However, the current code still works on 2.7.x. Tested the proposed fix on 3.8.1, 3.7.6, and 2.7.16, so it should be backward compatible with older versions of 3.8.

Traceback (most recent call last):
  File "generatejson.py", line 276, in <module>
    main()
  File "generatejson.py", line 249, in main
    (pkgId, pkgVersion) = getpkginfo(filePath)
  File "generatejson.py", line 93, in getpkginfo
    pkgInfoPath = extractpkginfo(filename)
  File "generatejson.py", line 74, in extractpkginfo
    pkgInfoPath = getpkginfopath(filename)
  File "generatejson.py", line 52, in getpkginfopath
    bom = bom.strip().split("\n")
TypeError: a bytes-like object is required, not 'str'