### PR TITLE
Git ignore a python framework that has been built.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 *.DS_Store
+payload/Library/installapplications/Python.framework


### PR DESCRIPTION
We don't need that in version control ;)